### PR TITLE
added scheduler

### DIFF
--- a/pkg/tensor/matmul.go
+++ b/pkg/tensor/matmul.go
@@ -2,7 +2,6 @@ package tensor
 
 import (
 	"fmt"
-	"runtime"
 	"sync"
 )
 
@@ -204,34 +203,26 @@ func matmulParallelBlocked(a, b, c []float64, m, n, p int) {
 		c[i] = 0.0
 	}
 
-	// Определяем количество воркеров (по числу ядер)
-	numWorkers := runtime.NumCPU()
-	if numWorkers > m {
-		numWorkers = m
-	}
-
-	// Разбиваем работу на блоки строк
-	blockRows := (m + numWorkers - 1) / numWorkers
-	if blockRows < BlockSize {
-		blockRows = BlockSize
-	}
+	numWorkers := matmulWorkerCount(m, BlockSize)
+	blockRows := matmulChunkRows(m, numWorkers, BlockSize)
+	scheduler := newMatmulRowScheduler(m, blockRows)
 
 	var wg sync.WaitGroup
 
 	// Запускаем воркеры
 	for w := 0; w < numWorkers; w++ {
-		startRow := w * blockRows
-		if startRow >= m {
-			break
-		}
-		endRow := min((w+1)*blockRows, m)
-
 		wg.Add(1)
-		go func(start, end int) {
+		go func() {
 			defer wg.Done()
-			// Блочное умножение для диапазона строк
-			matmulBlockedRange(a, b, c, start, end, n, p)
-		}(startRow, endRow)
+			for {
+				start, end, ok := scheduler.next()
+				if !ok {
+					return
+				}
+				// Блочное умножение для диапазона строк
+				matmulBlockedRange(a, b, c, start, end, n, p)
+			}
+		}()
 	}
 
 	wg.Wait()
@@ -449,39 +440,35 @@ func matmulParallelBlockedV2(a, b, c []float64, m, n, p int, blockSize int) {
 		c[i] = 0.0
 	}
 
-	numWorkers := runtime.NumCPU()
-	if numWorkers > m {
-		numWorkers = m
-	}
-	blockRows := (m + numWorkers - 1) / numWorkers
-	if blockRows < blockSize {
-		blockRows = blockSize
-	}
+	numWorkers := matmulWorkerCount(m, blockSize)
+	blockRows := matmulChunkRows(m, numWorkers, blockSize)
+	scheduler := newMatmulRowScheduler(m, blockRows)
 
 	var wg sync.WaitGroup
 	for w := 0; w < numWorkers; w++ {
-		startRow := w * blockRows
-		if startRow >= m {
-			break
-		}
-		endRow := min((w+1)*blockRows, m)
-
 		wg.Add(1)
-		go func(start, end int) {
+		go func() {
 			defer wg.Done()
 			packedB := make([]float64, blockSize*blockSize)
-			for jj := 0; jj < p; jj += blockSize {
-				jSize := min(blockSize, p-jj)
-				for kk := 0; kk < n; kk += blockSize {
-					kSize := min(blockSize, n-kk)
-					packBTileTransposed(b, packedB[:jSize*kSize], kk, jj, kSize, jSize, p)
-					for ii := start; ii < end; ii += blockSize {
-						iEnd := min(ii+blockSize, end)
-						matmulKernelPackedB(a, c, packedB[:jSize*kSize], ii, iEnd, kk, kSize, jj, jSize, n, p)
+			for {
+				start, end, ok := scheduler.next()
+				if !ok {
+					return
+				}
+
+				for jj := 0; jj < p; jj += blockSize {
+					jSize := min(blockSize, p-jj)
+					for kk := 0; kk < n; kk += blockSize {
+						kSize := min(blockSize, n-kk)
+						packBTileTransposed(b, packedB[:jSize*kSize], kk, jj, kSize, jSize, p)
+						for ii := start; ii < end; ii += blockSize {
+							iEnd := min(ii+blockSize, end)
+							matmulKernelPackedB(a, c, packedB[:jSize*kSize], ii, iEnd, kk, kSize, jj, jSize, n, p)
+						}
 					}
 				}
 			}
-		}(startRow, endRow)
+		}()
 	}
 
 	wg.Wait()

--- a/pkg/tensor/matmul_test.go
+++ b/pkg/tensor/matmul_test.go
@@ -1,6 +1,9 @@
 package tensor
 
 import (
+	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 )
 
@@ -347,6 +350,92 @@ func BenchmarkMatMulBlocked(b *testing.B) {
 	}
 }
 
+func TestMatMulLargeMatchesAcrossGOMAXPROCS(t *testing.T) {
+	a, b := benchmarkTensorSquare(192)
+
+	previous := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previous)
+
+	gotSingle, err := MatMul(a, b)
+	if err != nil {
+		t.Fatalf("MatMul() with GOMAXPROCS=1 error = %v", err)
+	}
+
+	runtime.GOMAXPROCS(4)
+	gotParallel, err := MatMul(a, b)
+	if err != nil {
+		t.Fatalf("MatMul() with GOMAXPROCS=4 error = %v", err)
+	}
+
+	if !shapesEqual(gotSingle.Shape, gotParallel.Shape) {
+		t.Fatalf("shape mismatch: single=%v parallel=%v", gotSingle.Shape, gotParallel.Shape)
+	}
+
+	for i := range gotSingle.Data {
+		if gotSingle.Data[i] != gotParallel.Data[i] {
+			t.Fatalf("data mismatch at %d: single=%v parallel=%v", i, gotSingle.Data[i], gotParallel.Data[i])
+		}
+	}
+}
+
+func TestMatMulConcurrentLarge(t *testing.T) {
+	a, b := benchmarkTensorSquare(192)
+
+	previous := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(previous)
+
+	expected, err := MatMul(a, b)
+	if err != nil {
+		t.Fatalf("MatMul() expected result error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 8)
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			got, err := MatMul(a, b)
+			if err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				return
+			}
+
+			for idx := range expected.Data {
+				if got.Data[idx] != expected.Data[idx] {
+					select {
+					case errCh <- &matmulMismatchError{index: idx, got: got.Data[idx], want: expected.Data[idx]}:
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type matmulMismatchError struct {
+	index int
+	got   float64
+	want  float64
+}
+
+func (e *matmulMismatchError) Error() string {
+	return fmt.Sprintf("matmul mismatch at %d: got %v want %v", e.index, e.got, e.want)
+}
+
 func BenchmarkMatMulBlockedV2(b *testing.B) {
 	size := 128
 	a := make([]float64, size*size)
@@ -434,5 +523,24 @@ func BenchmarkMatMulParallelBlockedV2_1024(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		matmulParallelBlockedV2(a.Data, c.Data, out, size, size, size, blockSize)
+	}
+}
+
+func BenchmarkMatMulParallelBlockedV2_1024_GOMAXPROCS(b *testing.B) {
+	size := 1024
+	a, c := benchmarkTensorSquare(size)
+	blockSize := chooseBlockSize(size, size, size)
+
+	for _, procs := range []int{1, 2, 4} {
+		b.Run(fmt.Sprintf("procs=%d", procs), func(b *testing.B) {
+			previous := runtime.GOMAXPROCS(procs)
+			defer runtime.GOMAXPROCS(previous)
+
+			out := make([]float64, size*size)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				matmulParallelBlockedV2(a.Data, c.Data, out, size, size, size, blockSize)
+			}
+		})
 	}
 }

--- a/pkg/tensor/scheduler.go
+++ b/pkg/tensor/scheduler.go
@@ -1,0 +1,96 @@
+package tensor
+
+import (
+	"runtime"
+	"sync/atomic"
+)
+
+// matmulRowScheduler раздаёт непересекающиеся диапазоны строк C.
+// Каждый worker получает эксклюзивный row-range, поэтому запись в результат не конфликтует.
+type matmulRowScheduler struct {
+	totalRows int
+	chunkRows int
+	nextRow   atomic.Int64
+}
+
+func newMatmulRowScheduler(totalRows, chunkRows int) *matmulRowScheduler {
+	if chunkRows < 1 {
+		chunkRows = 1
+	}
+
+	return &matmulRowScheduler{
+		totalRows: totalRows,
+		chunkRows: chunkRows,
+	}
+}
+
+func (s *matmulRowScheduler) next() (start, end int, ok bool) {
+	start = int(s.nextRow.Add(int64(s.chunkRows))) - s.chunkRows
+	if start >= s.totalRows {
+		return 0, 0, false
+	}
+
+	end = start + s.chunkRows
+	if end > s.totalRows {
+		end = s.totalRows
+	}
+
+	return start, end, true
+}
+
+func matmulWorkerCount(totalRows, blockSize int) int {
+	if totalRows <= 0 {
+		return 1
+	}
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+
+	rowChunks := ceilDiv(totalRows, max(1, blockSize))
+	if rowChunks > 0 && workers > rowChunks {
+		workers = rowChunks
+	}
+	if workers > totalRows {
+		workers = totalRows
+	}
+	if workers < 1 {
+		workers = 1
+	}
+
+	return workers
+}
+
+func matmulChunkRows(totalRows, workers, blockSize int) int {
+	if totalRows <= 0 {
+		return 1
+	}
+	if workers < 1 {
+		workers = 1
+	}
+
+	chunkRows := ceilDiv(totalRows, workers)
+	if blockSize > 1 {
+		chunkRows = ceilDiv(chunkRows, blockSize) * blockSize
+	}
+	if chunkRows < 1 {
+		chunkRows = 1
+	}
+
+	return chunkRows
+}
+
+func ceilDiv(x, y int) int {
+	if y <= 0 {
+		return 0
+	}
+	return (x + y - 1) / y
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/pkg/tensor/scheduler_test.go
+++ b/pkg/tensor/scheduler_test.go
@@ -1,0 +1,76 @@
+package tensor
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestMatmulWorkerCountUsesGOMAXPROCS(t *testing.T) {
+	previous := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previous)
+
+	if got := matmulWorkerCount(1024, 64); got != 1 {
+		t.Fatalf("matmulWorkerCount() with GOMAXPROCS=1 = %d, want 1", got)
+	}
+
+	runtime.GOMAXPROCS(4)
+	if got := matmulWorkerCount(1024, 64); got != 4 {
+		t.Fatalf("matmulWorkerCount() with GOMAXPROCS=4 = %d, want 4", got)
+	}
+
+	runtime.GOMAXPROCS(32)
+	if got := matmulWorkerCount(128, 64); got != 2 {
+		t.Fatalf("matmulWorkerCount() should cap workers by row chunks, got %d want 2", got)
+	}
+}
+
+func TestMatmulRowSchedulerProducesNonOverlappingRanges(t *testing.T) {
+	scheduler := newMatmulRowScheduler(130, 32)
+
+	seen := make([]bool, 130)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				start, end, ok := scheduler.next()
+				if !ok {
+					return
+				}
+
+				mu.Lock()
+				for row := start; row < end; row++ {
+					if seen[row] {
+						mu.Unlock()
+						select {
+						case errCh <- fmt.Errorf("row %d scheduled more than once", row):
+						default:
+						}
+						return
+					}
+					seen[row] = true
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+
+	for row, ok := range seen {
+		if !ok {
+			t.Fatalf("row %d was not scheduled", row)
+		}
+	}
+}


### PR DESCRIPTION
Thread Scheduler для больших матриц
DoD:

масштабируется по GOMAXPROCS

race detector зелёный


ОТЧЕТ

Добавлены:

`pkg/tensor/scheduler.go`

`pkg/tensor/scheduler_test.go`



Изменены:

pkg/tensor/matmul.go`

Изменения внесены в две функции:

- `matmulParallelBlocked`

- `matmulParallelBlockedV2`



`pkg/tensor/matmul_test.go`

- `TestMatMulLargeMatchesAcrossGOMAXPROCS`

Проверяет, что результат `MatMul` одинаков при `GOMAXPROCS=1` и `GOMAXPROCS=4`.

- `TestMatMulConcurrentLarge`

Запускает несколько конкурентных вызовов `MatMul` на больших матрицах и сверяет результат с эталоном.

`BenchmarkMatMulParallelBlockedV2_1024_GOMAXPROCS`

Он запускает parallel path для матриц `1024x1024` при:




- `GOMAXPROCS=1`

- `GOMAXPROCS=2`

- `GOMAXPROCS=4`



Запущены и успешно пройдены:




- `env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test ./pkg/tensor/...`

- `env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test -race ./pkg/tensor/...`




Результат:

- `pkg/tensor` — зелёный

- `pkg/tensor/graph` — зелёный

- `race detector` — зелёный



Результаты бенчмарков:

- `procs=1`: `409721467 ns/op`, `32936 B/op`, `4 allocs/op`

- `procs=2`: `313054922 ns/op`, `66072 B/op`, `6 allocs/op`

- `procs=4`: `179656001 ns/op`, `132829 B/op`, `12 allocs/op`